### PR TITLE
speculative changes; adding user_defined variable field to storage

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -242,7 +242,7 @@ Results that are returned from all instances of get_usage should **always** look
              'ip_info': str or None,
              'path': str,
              'speed': float,
-             'datetime': datetime,
+             'date': datetime,
              'username': str,
              'track_var': str(dict) or None,
      },

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -48,7 +48,7 @@ Usage
 ::
 
     # Create the Flask 'app'
-    from flask import Flask
+    from flask import Flask, g
     app = Flask(__name__)
 
     # Set the configuration items manually for the example
@@ -74,6 +74,7 @@ Usage
     @t.include
     @app.route('/')
     def index():
+        g.track_var["optional"] = "something"
         return "Hello"
 
     # Run the application!
@@ -233,7 +234,7 @@ Results that are returned from all instances of get_usage should **always** look
                  'version': str,
              },
              'blueprint': str,
-             'view_args': dict or None
+             'view_args': str(dict) or None,
              'status': int,
              'remote_addr': str,
              'xforwardedfor': str,
@@ -241,7 +242,9 @@ Results that are returned from all instances of get_usage should **always** look
              'ip_info': str or None,
              'path': str,
              'speed': float,
-             'date': datetime,
+             'datetime': datetime,
+             'username': str,
+             'track_var': str(dict) or None,
      },
      {
          ....
@@ -279,7 +282,7 @@ Not all Stores support all of these hooks. See the details for more information.
 
     from flask.ext.track_usage import TrackUsage
     from flask.ext.track_usage.storage.mongo import MongoEngineStorage
-    from flask.ext.track_usage.summarization import sumBasic
+    from flask.ext.track_usage.summarization import sumUrl
 
-    t = TrackUsage(app, [MongoEngineStorage(hooks=[sumBasic])])
+    t = TrackUsage(app, [MongoEngineStorage(hooks=[sumUrl])])
 

--- a/src/flask_track_usage/__init__.py
+++ b/src/flask_track_usage/__init__.py
@@ -113,6 +113,8 @@ class TrackUsage(object):
             raise NotImplementedError(
                 'You must set include or exclude type.')
         g.start_time = datetime.datetime.utcnow()
+        if not hasattr(g, "track_var"):
+            g.track_var = {}
 
     def after_request(self, response):
         """
@@ -173,7 +175,8 @@ class TrackUsage(object):
             'url_args': dict(
                 [(k, ctx.request.args[k]) for k in ctx.request.args]
             ),
-            'username': None
+            'username': None,
+            'track_var': g.track_var
         }
         if ctx.request.authorization:
             data['username'] = str(ctx.request.authorization.username)

--- a/src/flask_track_usage/storage/__init__.py
+++ b/src/flask_track_usage/storage/__init__.py
@@ -49,11 +49,6 @@ class _BaseWritable(object):
            - `args`: All non-keyword arguments.
            - `kwargs`: All keyword arguments.
         """
-        # if "hooks" in kwargs:
-        #     self._temp_hooks = kwargs["hooks"]
-        #     del kwargs["hooks"]
-        # else:
-        #     self._temp_hooks = []
         #
         self.set_up(*args, **kwargs)
         #

--- a/src/flask_track_usage/storage/mongo.py
+++ b/src/flask_track_usage/storage/mongo.py
@@ -193,6 +193,7 @@ class MongoEngineStorage(_MongoStorage):
             url_args = db.DictField()
             username = db.StringField()
             user_agent = db.EmbeddedDocumentField(UserAgent)
+            track_var = db.DictField()
             apache_combined_log = db.StringField()
             meta = {
                 'collection': "usageTracking"
@@ -221,6 +222,7 @@ class MongoEngineStorage(_MongoStorage):
         doc.content_length = data['content_length']
         doc.url_args = data['url_args']
         doc.username = data['username']
+        doc.track_var = data['track_var']
         # the following is VERY MUCH A HACK to allow a passed 'doc' on set_up
         ua = doc._fields['user_agent'].document_type_obj()
         ua.browser = data['user_agent'].browser

--- a/src/flask_track_usage/storage/sql.py
+++ b/src/flask_track_usage/storage/sql.py
@@ -108,7 +108,9 @@ class SQLStorage(Storage):
                     sql.Column('ip_info', sql.String(128)),
                     sql.Column('path', sql.String(32)),
                     sql.Column('speed', sql.Float),
-                    sql.Column('datetime', sql.DateTime)
+                    sql.Column('datetime', sql.DateTime),
+                    sql.Column('username', sql.String(128)),
+                    sql.Column('track_var', sql.String(128))
                 )
             else:
                 self._metadata.reflect(bind=self._eng)
@@ -142,7 +144,9 @@ class SQLStorage(Storage):
                 ip_info=data["ip_info"],
                 path=data["path"],
                 speed=data["speed"],
-                datetime=utcdatetime
+                datetime=utcdatetime,
+                username=data["username"],
+                track_var=json.dumps(data["track_var"], ensure_ascii=False)
             )
             con.execute(stmt)
         return data
@@ -179,7 +183,9 @@ class SQLStorage(Storage):
                 'ip_info': r[12],
                 'path': r[13],
                 'speed': r[14],
-                'date': r[15]
+                'datetime': r[15],
+                'username': r[16],
+                'track_var': r[17] if r[17] != '{}' else None
             } for r in raw_data]
         return usage_data
 

--- a/src/flask_track_usage/storage/sql.py
+++ b/src/flask_track_usage/storage/sql.py
@@ -183,7 +183,7 @@ class SQLStorage(Storage):
                 'ip_info': r[12],
                 'path': r[13],
                 'speed': r[14],
-                'datetime': r[15],
+                'date': r[15],
                 'username': r[16],
                 'track_var': r[17] if r[17] != '{}' else None
             } for r in raw_data]

--- a/test/test_storage_sqlalchemy.py
+++ b/test/test_storage_sqlalchemy.py
@@ -186,7 +186,7 @@ class TestSQLiteStorage(FlaskTrackUsageTestCase):
         assert result[12] == result2['ip_info']
         assert result[13] == result2['path']
         assert result[14] == result2['speed']
-        assert result[15] == result2['datetime']
+        assert result[15] == result2['date']
         assert result[16] == result2['username']
         track_var = result[17] if result[17] != '{}' else None
         assert track_var == result2['track_var']
@@ -209,7 +209,7 @@ class TestSQLiteStorage(FlaskTrackUsageTestCase):
         assert result[12] == result2['ip_info']
         assert result[13] == result2['path']
         assert result[14] == result2['speed']
-        assert result[15] == result2['datetime']
+        assert result[15] == result2['date']
         assert result[16] == result2['username']
         track_var = result[17] if result[17] != '{}' else None
         assert track_var == result2['track_var']
@@ -242,7 +242,7 @@ class TestSQLiteStorage(FlaskTrackUsageTestCase):
             assert result[i][12] == result2[i]['ip_info']
             assert result[i][13] == result2[i]['path']
             assert result[i][14] == result2[i]['speed']
-            assert result[i][15] == result2[i]['datetime']
+            assert result[i][15] == result2[i]['date']
             assert result[i][16] == result2[i]['username']
             track_var = result[i][17] if result[i][17] != '{}' else None
             assert track_var == result2[i]['track_var']

--- a/test/test_storage_sqlalchemy.py
+++ b/test/test_storage_sqlalchemy.py
@@ -186,7 +186,10 @@ class TestSQLiteStorage(FlaskTrackUsageTestCase):
         assert result[12] == result2['ip_info']
         assert result[13] == result2['path']
         assert result[14] == result2['speed']
-        assert result[15] == result2['date']
+        assert result[15] == result2['datetime']
+        assert result[16] == result2['username']
+        track_var = result[17] if result[17] != '{}' else None
+        assert track_var == result2['track_var']
 
     def test_storage_get_usage(self):
         self.client.get('/')
@@ -206,7 +209,10 @@ class TestSQLiteStorage(FlaskTrackUsageTestCase):
         assert result[12] == result2['ip_info']
         assert result[13] == result2['path']
         assert result[14] == result2['speed']
-        assert result[15] == result2['date']
+        assert result[15] == result2['datetime']
+        assert result[16] == result2['username']
+        track_var = result[17] if result[17] != '{}' else None
+        assert track_var == result2['track_var']
 
     def test_storage_get_usage_pagination(self):
         # test pagination
@@ -236,7 +242,10 @@ class TestSQLiteStorage(FlaskTrackUsageTestCase):
             assert result[i][12] == result2[i]['ip_info']
             assert result[i][13] == result2[i]['path']
             assert result[i][14] == result2[i]['speed']
-            assert result[i][15] == result2[i]['date']
+            assert result[i][15] == result2[i]['datetime']
+            assert result[i][16] == result2[i]['username']
+            track_var = result[i][17] if result[i][17] != '{}' else None
+            assert track_var == result2[i]['track_var']
 
 
 @unittest.skipUnless(HAS_POSTGRES, "Requires psycopg2 Postgres package")


### PR DESCRIPTION
This is purely speculative.

But I suspect this might be a compelling thing to use in this library. To put in context why, I did a quick retake of the video intro:

https://youtu.be/bd7__OGGgGY   (unlisted)

Essentially, this adds support for new dictionary variable in `g` called `g.track_var`. The user can now place _any_ kind of data into the dictionary. On a SQL storage, it should create a JSON string of the dictionary. On Mongo storage, it should store the dictionary as-is.

I've only fully tested MongoEngine, but have the basics elsewhere. I've speculatively updated the `app.py` example in the demo to show it's usage. See https://github.com/JohnAD/flask-track-usage-mongoengine-demo/blob/master/app.py

Does this sound like a good addition for 2.0? It does add extra fields to the SQL Storage so it is a breaking upgrade as the user would need to update the structure of the table.

Two other minor changes:

* also added 'username' to the SQL storage
* changed the `get_usage` name of `date` to `datetime` to match up with the SQL fieldname.