### PR TITLE
update doc to use flask_track_usage

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -58,7 +58,7 @@ Usage
     app.config['TRACK_USAGE_INCLUDE_OR_EXCLUDE_VIEWS'] = 'include'
 
     # We will just print out the data for the example
-    from flask.ext.track_usage import TrackUsage
+    from flask_track_usage import TrackUsage
 
     # We will just print out the data for the example
     from flask_track_usage.storage.printer import PrintWriter


### PR DESCRIPTION
from flask_track_usage import TrackUsage

tested on my local machine 

https://github.com/onewyoming/onewyoming/commit/c9846011e24f3eba3ac80487919deb2fd9d99f24 

https://gitlab.com/wyoming/wyoming.gitlab.io/commit/c9846011e24f3eba3ac80487919deb2fd9d99f24

I think this is for new versions of flask but this should be OK because the documentation should work on the latest version of flask as that's what newcomers will likely try this on 