### PR TITLE
limit ip_info to 128 bytes is too restrictive

### DIFF
--- a/src/flask_track_usage/storage/sql.py
+++ b/src/flask_track_usage/storage/sql.py
@@ -135,7 +135,7 @@ class SQLStorage(Storage):
             t = {}
             for key in data["ip_info"]:
                 t[key] = data["ip_info"][key]
-                if len(json.dumps(t)) > 128:
+                if not len(json.dumps(t)) < 1024:
                     del t[key]
                     break
             ip_info_str = json.dumps(t)


### PR DESCRIPTION
Field ip_info is allocated with 1024 bytes in length.  It's too restrictive to limit it to 128 bytes.